### PR TITLE
v8 - Holiday Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,22 @@
 Changelog
 ---
 
+# 8.0.0 [Holiday Release]
+
+**3 New Dark Themes!**
+ 
+- Celebrate Christmas with Chocola from the NekoPara Series!
+_I lied about Shigure being the last addition from NekoPara._
+
+- The 4th of July now just got even better, now that you can code with Essex from Azur Lane.
+If you prefer a more canon experience, Essex's theme also has **secondary content** with the Eagle Union branding.
+
+- Even though I missed this year's Halloween, I've got something to look forward to in 2022.
+Yotsuba, from The Quintessential Quintuplets, isn't 2spooky4me.
+
+
+![v22 Girls](https://doki.assets.unthrottled.io/misc/v22_girls.png)
+
 # 7.0.0 [Jahy-sama will not be discouraged!]
 
 **1 New Theme!**

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This Python package is for serious Otaku data enthusiasts.
 
 You can choose themes from various, Anime, Manga, or Visual Novels:
 
+- AzurLane
 - Blend S
 - Daily life with a monster girl
 - DanganRonpa

--- a/buildSrc/assets/themes/azurLane/essex/dark/essex.dark.jupyter.definition.json
+++ b/buildSrc/assets/themes/azurLane/essex/dark/essex.dark.jupyter.definition.json
@@ -1,11 +1,14 @@
 {
-  "id": "91d0931d-3e1d-4101-b923-278ce264f0f5",
+  "id": "e55e70ea-454b-47ef-9270-d46390dd2769",
   "overrides": {},
   "laf": {},
   "syntax": {},
   "colors": {},
   "backgrounds": {
     "default": {
+      "anchor": "right"
+    },
+    "secondary": {
       "anchor": "right"
     }
   }

--- a/buildSrc/assets/themes/fate/rin/dark/rin.dark.jupyter.definition.json
+++ b/buildSrc/assets/themes/fate/rin/dark/rin.dark.jupyter.definition.json
@@ -3,5 +3,10 @@
   "overrides": {},
   "laf": {},
   "syntax": {},
-  "colors": {}
+  "colors": {},
+  "backgrounds": {
+    "default": {
+      "anchor": "right"
+    }
+  }
 }

--- a/buildSrc/assets/themes/nekoPara/chocola/xmas/chocola.xmas.jupyter.definition.json
+++ b/buildSrc/assets/themes/nekoPara/chocola/xmas/chocola.xmas.jupyter.definition.json
@@ -1,12 +1,12 @@
 {
-  "id": "91d0931d-3e1d-4101-b923-278ce264f0f5",
+  "id": "6428e1ff-202c-4a43-afb3-9999ebe3b2ca",
   "overrides": {},
   "laf": {},
   "syntax": {},
   "colors": {},
   "backgrounds": {
     "default": {
-      "anchor": "right"
+      "anchor": "center"
     }
   }
 }

--- a/buildSrc/assets/themes/quintuplets/yotsuba/dark/yotsuba.dark.jupyter.definition.json
+++ b/buildSrc/assets/themes/quintuplets/yotsuba/dark/yotsuba.dark.jupyter.definition.json
@@ -1,5 +1,5 @@
 {
-  "id": "91d0931d-3e1d-4101-b923-278ce264f0f5",
+  "id": "3b11c8f4-d030-4a7e-a46f-b22d3e430a1d",
   "overrides": {},
   "laf": {},
   "syntax": {},

--- a/buildSrc/buildInstallThemes.sh
+++ b/buildSrc/buildInstallThemes.sh
@@ -4,7 +4,8 @@ yarn buildThemes
 cd ../src
 #python3 -m src/dokithemejupyter --set-theme "Franxx: Zero Two Dark"
 #python3 -m dokithemejupyter --set-theme "NekoPara: Maple Dark" --sticker
-python3 -m dokithemejupyter --set-theme "KillLaKill: Ryuko" --sticker
+python3 -m dokithemejupyter --set-theme "KillLaKill: Ryuko Dark" --sticker
+#python3 -m dokithemejupyter --set-theme "NekoPara: Christmas Chocola" --sticker
 #python3 -m dokithemejupyter --set-theme "JahySama: Jahy" --sticker
 #python3 -m dokithemejupyter --set-theme "NekoPara: Shigure" --sticker
 #python3 -m src/dokithemejupyter --set-theme "OreGairu: Yukinoshita Yukino"

--- a/buildSrc/package.json
+++ b/buildSrc/package.json
@@ -13,7 +13,7 @@
     "@types/lodash": "^4.14.155",
     "@types/xml2js": "^0.4.5",
     "copy-webpack-plugin": "^6.0.2",
-    "doki-build-source": "1.7.0",
+    "doki-build-source": "1.8.0",
     "jest": "^26.0.1",
     "rimraf": "^3.0.2",
     "ts-jest": "^26.1.0",

--- a/buildSrc/yarn.lock
+++ b/buildSrc/yarn.lock
@@ -1895,10 +1895,10 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
-doki-build-source@1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/doki-build-source/-/doki-build-source-1.7.0.tgz#d90402b8f02e80d8b0376d86d48e57ba7be991e8"
-  integrity sha512-E2PCaT2lNAEZVHhl6cDRah9KqWf/M6S59YgfwHU7N3HBtDl6ld8U6Np9f5UUQPtquLb47UC2R+CvN2t8SKXRhw==
+doki-build-source@1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/doki-build-source/-/doki-build-source-1.8.0.tgz#30f82942eca97f4091697302e55ff5504a7bf42e"
+  integrity sha512-l7gvHdcptjruHPVe0KB5UgY9lTjtbxC8aqE2ds4+eD78OttjCgUrfJjAVeeY0tF2cp3vZ8+3eUB9EthbuwL3eQ==
 
 domain-browser@^1.1.1:
   version "1.2.0"

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ import pathlib
 
 here = pathlib.Path(__file__).parent.resolve()
 
-version = '7.0.0'
+version = '8.0.0'
 
 # write current version
 with open((here / 'src' / 'dokithemejupyter' / 'version.txt'), 'w') as version_file:


### PR DESCRIPTION

**3 New Dark Themes!**
 
- Celebrate Christmas with Chocola from the NekoPara Series!
_I lied about Shigure being the last addition from NekoPara._

- The 4th of July now just got even better, now that you can code with Essex from Azur Lane.
If you prefer a more canon experience, Essex's theme also has **secondary content** with the Eagle Union branding.

- Even though I missed this year's Halloween, I've got something to look forward to in 2022.
Yotsuba, from The Quintessential Quintuplets, isn't 2spooky4me.


![v22 Girls](https://doki.assets.unthrottled.io/misc/v22_girls.png)

#### Other Stuff

- Moved Tohsaka Rin's wallpaper over to the right.

#### Screens

**Chocola**
![Screenshot from 2021-12-07 18-14-44](https://user-images.githubusercontent.com/15972415/145125856-82e4b8c4-34e8-4731-b960-517cba1e2ded.png)

**Essex**
![Screenshot from 2021-12-07 18-11-51](https://user-images.githubusercontent.com/15972415/145125851-8737dd55-bcdb-4181-864d-56ed2aa348d6.png)

**Yotsuba**
![Screenshot from 2021-12-07 18-10-19](https://user-images.githubusercontent.com/15972415/145125849-f3c958e9-3c33-452f-82a8-4177692ed94b.png)


